### PR TITLE
Generics in reexport of client.

### DIFF
--- a/DurableObject/index.ts
+++ b/DurableObject/index.ts
@@ -1,7 +1,8 @@
+import { Error } from "../Error"
 import { Alarm } from "./Alarm"
 import { Client as ClientClass } from "./Client"
 import { Namespace } from "./Namespace"
 
-type Client = ClientClass // only export interface
+type Client<E = Error> = ClientClass<E> // only export interface
 
 export { Alarm, Client, Namespace }


### PR DESCRIPTION
Fix forgotten generic type when re-exporting Durable Object client.

The generic parameter is optional so it should be backward compatible. 