### PR TITLE
Fake domain for logging

### DIFF
--- a/DurableObject/Client.ts
+++ b/DurableObject/Client.ts
@@ -7,11 +7,18 @@ export class Client<E = Error> {
 	get id(): string {
 		return this.stub.id.toString()
 	}
-	constructor(private readonly stub: platform.DurableObjectStub) {}
+	/**
+	 * This domain is only for logging purpose.
+	 * The domain is ignored, but requests are written in the log.
+	 */
+	private fakeDomain: string
+	constructor(private readonly stub: platform.DurableObjectStub) {
+		this.fakeDomain = this.stub.name?.replace(/\W/g, "") || this.stub.id.toString()
+	}
 
 	private async fetch<R>(path: string, method: http.Method, body?: any, header?: http.Request.Header): Promise<R | E> {
 		const request = http.Request.create({
-			url: `https://origin${path}`,
+			url: `https://${this.fakeDomain}${path}`,
 			method: method,
 			header: { ...(body ? { contentType: "application/json" } : {}), ...(header ? header : {}) },
 			body,

--- a/DurableObject/Client.ts
+++ b/DurableObject/Client.ts
@@ -13,7 +13,7 @@ export class Client<E = Error> {
 	 */
 	private fakeDomain: string
 	constructor(private readonly stub: platform.DurableObjectStub) {
-		this.fakeDomain = this.stub.name?.replace(/\W/g, "") || this.stub.id.toString()
+		this.fakeDomain = this.stub.name?.replace(/[^\w-]/g, "") || `do-${this.id}`
 	}
 
 	private async fetch<R>(path: string, method: http.Method, body?: any, header?: http.Request.Header): Promise<R | E> {


### PR DESCRIPTION
Uses name or id of Durable Object as domain for requests to durable objects.
Only for better logging.