### PR TITLE
Made it so that OnlyMeta.list doesn't accidentally call get on each of its entries.

### DIFF
--- a/KeyValueStore/OnlyMeta/index.ts
+++ b/KeyValueStore/OnlyMeta/index.ts
@@ -25,7 +25,9 @@ export namespace OnlyMeta {
 				)
 			},
 			list: async (options?: string | ListOptions): Promise<Continuable<ListItem<V, undefined>>> => {
-				const response = await backend.list(options)
+				const response = await backend.list(
+					typeof options == "string" ? { prefix: options, values: false } : { ...options, values: false }
+				)
 				const cont = Continuable.create(response, response.cursor)
 				const result: Continuable<ListItem<V, undefined>> = await Promise.all(
 					cont.map(async item => ({


### PR DESCRIPTION
Due to the default behaviour of FromPlatform.list, OnlyMeta.list would cause it to do a get on each of its entries if you forgot to call it with values: false, which would invalidate the entire point of using it. Should now be foolproof.