### PR TITLE
replaced main with module in package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,8 +43,8 @@
 	"editor.formatOnSave": true,
 	"editor.formatOnPaste": true,
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true,
-		"eslint.autoFixOnSave": true,
+		"source.fixAll.eslint": "explicit",
+		"eslint.autoFixOnSave": "explicit"
 	},
 	"eslint.format.enable": true,
 	"eslint.lintTask.enable": true,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"homepage": "https://github.com/utily",
 	"private": false,
-	"main": "dist/index.js",
+	"module": "dist/index.js",
 	"typings": "dist/index.d.ts",
 	"type": "module",
 	"git": {


### PR DESCRIPTION
The `main` field is used to specify cjs imports but this library only builds to esm. The `module` field is used for esm.
This removed all rollup build warnings when using this as a dependency since rollup thought the esm was cjs.

* replaced `main` field with `module` in `package.json` 